### PR TITLE
fix altitude export to scale by 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Example:
     activities = callbacks.activities #assumes you have some sort of getter/attr_reader on your custom callbacks class
 
 When I get more time I'll document the messages, but for now you can look in ext/rubyfit/rubyfit.c to see what fields are being passed.
+
+To build and test the gem, run:
+```
+bundle install
+rake
+```

--- a/lib/rubyfit/type.rb
+++ b/lib/rubyfit/type.rb
@@ -147,8 +147,8 @@ class RubyFit::Type
 
     def altitude
       uint16({
-        rb2fit: ->(val, type) { (val + 500).truncate },
-        fit2rb: ->(val, type) { val - 500 }
+        rb2fit: ->(val, type) { (5 * val + 500).truncate },
+        fit2rb: ->(val, type) { (val - 500) / 5 }
       })
     end
 

--- a/lib/rubyfit/version.rb
+++ b/lib/rubyfit/version.rb
@@ -1,3 +1,3 @@
 module Rubyfit
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -78,7 +78,7 @@ describe RubyFit::Writer do
     end
 
     def altitude_bytes(meters)
-      num2bytes((meters + 500).truncate, 2)
+      num2bytes((meters * 5 + 500).truncate, 2)
     end
 
     def duration_bytes(seconds)
@@ -274,7 +274,7 @@ describe RubyFit::Writer do
         *position_bytes(data[:y]), # lat
         *position_bytes(data[:x]), # lng
         *distance_bytes(distance), # distance
-        *altitude_bytes(data[:elevation]), # distance
+        *altitude_bytes(data[:elevation]), # elevation
       ]
       
       expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)


### PR DESCRIPTION
see all the examples of altitude like this: https://github.com/ridewithgps/rubyfit/blob/master/ext/rubyfit/fit_example.h#L3402

i have no idea how to test this. helpppp

fixes https://github.com/ridewithgps/ridewithgps/issues/5110