### PR TITLE
fixed altitude calculations

### DIFF
--- a/lib/rubyfit/type.rb
+++ b/lib/rubyfit/type.rb
@@ -147,8 +147,8 @@ class RubyFit::Type
 
     def altitude
       uint16({
-        rb2fit: ->(val, type) { (5 * val + 500).truncate },
-        fit2rb: ->(val, type) { (val - 500) / 5 }
+        rb2fit: ->(val, type) { ((val + 500) * 5).truncate },
+        fit2rb: ->(val, type) { val / 5.0 - 500 }
       })
     end
 

--- a/lib/rubyfit/version.rb
+++ b/lib/rubyfit/version.rb
@@ -1,3 +1,3 @@
 module Rubyfit
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -78,7 +78,7 @@ describe RubyFit::Writer do
     end
 
     def altitude_bytes(meters)
-      num2bytes((meters * 5 + 500).truncate, 2)
+      num2bytes(((meters + 500) * 5).truncate, 2)
     end
 
     def duration_bytes(seconds)


### PR DESCRIPTION
i made a previous pull request to fix these: https://github.com/ridewithgps/rubyfit/pull/7

i referenced ext/rubyfit/fit_example.h which repeatedly comments altitude fields with `5 * m + 500`. unfortunately this is very wrong, and it's actually `5 * (m + 500)`. the difference in these calculations results in a -400 meter offset, which we have had users report in our fit files.

if we go to the actual documentation in the fit sdk, you see the correct calculation:

![](http://i.hamzog.com/27559ac7208eb8d5_13_06.png)