### PR TITLE
Add mandatory print_msg method

### DIFF
--- a/examples/fit_callbacks.rb
+++ b/examples/fit_callbacks.rb
@@ -1,6 +1,10 @@
 class FitCallbacks
   def initialize()
   end
+  
+  def print_msg(msg)
+    puts msg
+  end
 
   def on_activity(msg)
     #puts "activity: #{msg.inspect}"


### PR DESCRIPTION
Since `print_msg` is a required method that is called by `rubyfit/ext/rubyfit/rubyfit.c` it should be mentioned in this example.