### PR TITLE
Parse file_id messages

### DIFF
--- a/examples/fit_callbacks.rb
+++ b/examples/fit_callbacks.rb
@@ -1,9 +1,13 @@
 class FitCallbacks
   def initialize()
   end
-  
+
   def print_msg(msg)
     puts msg
+  end
+
+  def on_file_id(msg)
+    #puts "file id: #{msg.inspect}"
   end
 
   def on_activity(msg)

--- a/ext/rubyfit/rubyfit.c
+++ b/ext/rubyfit/rubyfit.c
@@ -50,6 +50,27 @@ static VALUE init(VALUE self, VALUE handler) {
 	return Qnil;
 }
 
+static void pass_file_id(VALUE handler, const FIT_FILE_ID_MESG *mesg) {
+	VALUE rh = rb_hash_new();
+
+	if(mesg->serial_number != FIT_UINT32Z_INVALID)
+		rb_hash_aset(rh, rb_str_new2("serial_number"), UINT2NUM(mesg->serial_number));
+	if(mesg->time_created != FIT_DATE_TIME_INVALID)
+		rb_hash_aset(rh, rb_str_new2("time_created"), UINT2NUM(mesg->time_created + GARMIN_TIME_OFFSET));
+	if(*mesg->product_name != FIT_STRING_INVALID)
+		rb_hash_aset(rh, rb_str_new2("product_name"), rb_str_new2(mesg->product_name));
+	if(mesg->manufacturer != FIT_MANUFACTURER_INVALID)
+		rb_hash_aset(rh, rb_str_new2("manufacturer"), UINT2NUM(mesg->manufacturer));
+	if(mesg->product != FIT_UINT16_INVALID)
+		rb_hash_aset(rh, rb_str_new2("product"), UINT2NUM(mesg->product));
+	if(mesg->number != FIT_UINT16_INVALID)
+		rb_hash_aset(rh, rb_str_new2("number"), UINT2NUM(mesg->number));
+	if(mesg->type != FIT_FILE_INVALID)
+		rb_hash_aset(rh, rb_str_new2("type"), CHR2FIX(mesg->type));
+
+	rb_funcall(handler, rb_intern("on_file_id"), 1, rh);
+}
+
 static void pass_activity(VALUE handler, const FIT_ACTIVITY_MESG *mesg) {
 	VALUE rh = rb_hash_new();
 
@@ -437,6 +458,8 @@ static VALUE parse(VALUE self, VALUE original_str) {
 
 					switch(mesg_num) {
 						case FIT_MESG_NUM_FILE_ID: {
+							const FIT_FILE_ID_MESG *file_id = (FIT_FILE_ID_MESG *) mesg;
+							pass_file_id(handler, file_id);
 							break;
 						}
 

--- a/lib/rubyfit/version.rb
+++ b/lib/rubyfit/version.rb
@@ -1,3 +1,3 @@
 module Rubyfit
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end

--- a/lib/rubyfit/writer.rb
+++ b/lib/rubyfit/writer.rb
@@ -1,7 +1,7 @@
 require "rubyfit/message_writer"
 
 class RubyFit::Writer
-  PRODUCT_ID = 65534 # Garmin Connect
+  GARMIN_CONNECT_PRODUCT_ID = 65534
 
   def write(stream, opts = {})
     raise "Can't start write mode from #{@state}" if @state
@@ -24,11 +24,12 @@ class RubyFit::Writer
     data_size = calculate_data_size(opts[:course_point_count], opts[:track_point_count])
     write_data(RubyFit::MessageWriter.file_header(data_size))
 
+    # TODO support passing in manufacturer and product via opts
     write_message(:file_id, {
       time_created: opts[:time_created],
       type: 6, # Course file
       manufacturer: 1, # Garmin
-      product: PRODUCT_ID,
+      product: GARMIN_CONNECT_PRODUCT_ID,
       serial_number: 0,
     })
 
@@ -107,7 +108,7 @@ class RubyFit::Writer
       time_created: opts[:time_created].to_i,
       type: 4, # Activity file
       manufacturer: 1, # Garmin
-      product: PRODUCT_ID,
+      product: GARMIN_CONNECT_PRODUCT_ID,
       serial_number: 0
     })
 

--- a/spec/rubyfit/parser_spec.rb
+++ b/spec/rubyfit/parser_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+require 'date'
+
+describe RubyFit::FitParser do
+  class TestCallbacks
+    attr_reader :file_id, :lap, :records, :events
+
+    def initialize
+      @file_id = nil
+      @lap = nil
+      @records = []
+      @events = []
+    end
+
+    def print_msg(msg)
+    end
+
+    def print_error_msg(msg)
+    end
+
+    def on_file_id(msg)
+      @file_id = msg
+    end
+
+    def on_activity(msg)
+    end
+
+    def on_lap(msg)
+      @lap = msg
+    end
+
+    def on_session(msg)
+    end
+
+    def on_record(msg)
+      @records << msg
+    end
+
+    def on_event(msg)
+      @events << msg
+    end
+
+    def on_device_info(msg)
+    end
+
+    def on_user_profile(msg)
+    end
+
+    def on_weight_scale_info(msg)
+    end
+  end
+
+  describe "#parse" do
+    let(:start_time) { DateTime.new(2025, 1, 1, 12, 0, 0).to_time.to_i }
+
+    let(:test_fit_data) do
+      # Generate a simple FIT file for testing
+      writer = RubyFit::Writer.new
+      stream = StringIO.new
+
+      track_points = [
+        {x: -122.64424, y: 45.5279, distance: 0, elevation: 100.0},
+        {x: -122.64355, y: 45.5279, distance: 53.81, elevation: 150.0}
+      ]
+
+      opts = {
+        time_created: start_time,
+        start_time: start_time,
+        duration: 100,
+        start_x: track_points.first[:x],
+        start_y: track_points.first[:y],
+        end_x: track_points.last[:x],
+        end_y: track_points.last[:y],
+        total_distance: track_points.last[:distance],
+        name: "test course",
+        track_point_count: track_points.size,
+        course_point_count: 0,
+      }
+
+      writer.write(stream, opts) do
+        writer.course_points { }
+        writer.track_points do
+          track_points.each_with_index do |data, i|
+            writer.track_point(data.merge(timestamp: start_time + i * 50))
+          end
+        end
+      end
+
+      stream.string
+    end
+
+    it "parses a FIT file and verifies all data from opts" do
+      callbacks = TestCallbacks.new
+      parser = RubyFit::FitParser.new(callbacks)
+
+      parser.parse(test_fit_data)
+
+      # Verify file_id fields
+      expect(callbacks.file_id["type"]).to eq(6) # Course file type
+      expect(callbacks.file_id["manufacturer"]).to eq(1) # Garmin
+      expect(callbacks.file_id["product"]).to eq(RubyFit::Writer::GARMIN_CONNECT_PRODUCT_ID) # 65534
+      expect(callbacks.file_id["time_created"]).to eq(start_time)
+
+      # Verify lap fields
+      expect(callbacks.lap["start_time"]).to eq(start_time)
+      expect(callbacks.lap["timestamp"]).to eq(start_time)
+      expect(callbacks.lap["total_elapsed_time"]).to eq(100000) # duration in milliseconds
+      expect(callbacks.lap["total_timer_time"]).to eq(100.0) # duration in seconds (divided by 1000)
+      expect(callbacks.lap["start_position_lat"]).to be_within(0.00001).of(45.5279)
+      expect(callbacks.lap["start_position_long"]).to be_within(0.00001).of(-122.64424)
+      expect(callbacks.lap["end_position_lat"]).to be_within(0.00001).of(45.5279)
+      expect(callbacks.lap["end_position_long"]).to be_within(0.00001).of(-122.64355)
+      expect(callbacks.lap["total_distance"]).to be_within(0.01).of(53.81)
+
+      # Verify track points
+      expect(callbacks.records.size).to eq(2)
+      expect(callbacks.records[0]["position_lat"]).to be_within(0.00001).of(45.5279)
+      expect(callbacks.records[0]["position_long"]).to be_within(0.00001).of(-122.64424)
+      expect(callbacks.records[0]["altitude"]).to eq(100.0)
+      expect(callbacks.records[1]["position_lat"]).to be_within(0.00001).of(45.5279)
+      expect(callbacks.records[1]["position_long"]).to be_within(0.00001).of(-122.64355)
+      expect(callbacks.records[1]["altitude"]).to eq(150.0)
+
+      # Verify events
+      expect(callbacks.events.size).to eq(2) # start and stop events
+    end
+  end
+end


### PR DESCRIPTION
This adds a callback for the file_id message. Notably, this message includes manufacturer id and product id. While device_info messages also provide those fields, some manufacturers don't include the product id in device_info.