### PR TITLE
Support writing more fields: avg_heart_rate, avg_cadence, manufacturer, product

### DIFF
--- a/lib/rubyfit/version.rb
+++ b/lib/rubyfit/version.rb
@@ -1,3 +1,3 @@
 module Rubyfit
-  VERSION = "0.0.17"
+  VERSION = "0.0.18"
 end

--- a/lib/rubyfit/writer.rb
+++ b/lib/rubyfit/writer.rb
@@ -1,6 +1,7 @@
 require "rubyfit/message_writer"
 
 class RubyFit::Writer
+  GARMIN_MANUFACTURER_ID = 1
   GARMIN_CONNECT_PRODUCT_ID = 65534
 
   def write(stream, opts = {})
@@ -24,12 +25,13 @@ class RubyFit::Writer
     data_size = calculate_data_size(opts[:course_point_count], opts[:track_point_count])
     write_data(RubyFit::MessageWriter.file_header(data_size))
 
-    # TODO support passing in manufacturer and product via opts
+    manufacturer, product = extract_manufacturer_and_product(opts)
+
     write_message(:file_id, {
       time_created: opts[:time_created],
       type: 6, # Course file
-      manufacturer: 1, # Garmin
-      product: GARMIN_CONNECT_PRODUCT_ID,
+      manufacturer: manufacturer,
+      product: product,
       serial_number: 0,
     })
 
@@ -77,10 +79,12 @@ class RubyFit::Writer
   #   :total_distance (Integer centimeters)
   #   :sport (Symbol, e.g., :running, see MessageConstants::SPORT)
   #   :sub_sport (Symbol, e.g., :generic, see MessageConstants::SUB_SPORT)
-  # Optional opts (used in lap/session messages):
+  # Optional opts used in lap/session messages:
   #   :start_x, :start_y, :end_x, :end_y lat/long coordinates
   #   :total_calories, :total_ascent, :total_descent, :avg_speed, :max_speed
   #   :avg_heart_rate, :avg_cadence
+  # Optional opts used in file_id message:
+  #   :manufacturer, :product
   def write_activity(stream, opts = {})
     raise "Can't start write mode from #{@state}" if @state
     @state = :write
@@ -104,12 +108,14 @@ class RubyFit::Writer
     data_size = calculate_activity_data_size(opts[:track_point_count])
     write_data(RubyFit::MessageWriter.file_header(data_size))
 
+    manufacturer, product = extract_manufacturer_and_product(opts)
+
     # File ID Message
     write_message(:file_id, {
       time_created: opts[:time_created].to_i,
       type: 4, # Activity file
-      manufacturer: 1, # Garmin
-      product: GARMIN_CONNECT_PRODUCT_ID,
+      manufacturer: manufacturer,
+      product: product,
       serial_number: 0
     })
 
@@ -220,6 +226,16 @@ class RubyFit::Writer
   end
 
   protected
+
+  def extract_manufacturer_and_product(opts)
+    if opts.keys.intersect?([:manufacturer, :product])
+      raise ArgumentError.new("Missing manufacturer but provided product") unless opts.has_key?(:manufacturer)
+      raise ArgumentError.new("Missing product but provided manufacturer") unless opts.has_key?(:product)
+      [opts[:manufacturer], opts[:product]]
+    else
+      [GARMIN_MANUFACTURER_ID, GARMIN_CONNECT_PRODUCT_ID]
+    end
+  end
 
   def write_message(type, values)
     local_num = @local_nums[type]

--- a/lib/rubyfit/writer.rb
+++ b/lib/rubyfit/writer.rb
@@ -79,7 +79,8 @@ class RubyFit::Writer
   #   :sub_sport (Symbol, e.g., :generic, see MessageConstants::SUB_SPORT)
   # Optional opts (used in lap/session messages):
   #   :start_x, :start_y, :end_x, :end_y lat/long coordinates
-  #   :total_calories, :total_ascent, :total_descent, :avg_speed, :max_speed, etc.
+  #   :total_calories, :total_ascent, :total_descent, :avg_speed, :max_speed
+  #   :avg_heart_rate, :avg_cadence
   def write_activity(stream, opts = {})
     raise "Can't start write mode from #{@state}" if @state
     @state = :write
@@ -171,7 +172,7 @@ class RubyFit::Writer
       sub_sport: opts[:sub_sport] || :generic
     }.merge(
       # Add optional session fields if available
-      opts.select { |k, _| %i[total_ascent total_descent avg_speed total_calories total_distance max_speed].include?(k) }
+      opts.select { |k, _| %i[total_ascent total_descent avg_speed total_calories total_distance max_speed avg_heart_rate avg_cadence].include?(k) }
     ) # Merge common optional fields
     write_message(:session, session_data)
 

--- a/spec/rubyfit/message_writer_spec.rb
+++ b/spec/rubyfit/message_writer_spec.rb
@@ -128,13 +128,16 @@ describe RubyFit::MessageWriter do
         0, # Padding
         1, # Big endian
         0, 20, # Global message number
-        5, # Field count
+        8, # Field count
         # Fields are 3 bytes each - field ID, size in bytes, type ID
         253, 4, 134, # timestamp
         0, 4, 133, # position lat
         1, 4, 133, # position long
         5, 4, 134, # distance
         2, 2, 132, # elevation
+        3, 1, 2, # heart_rate
+        4, 1, 2, # cadence
+        7, 2, 132, # power
       ]
       expect(bytes).to eq(expected_bytes)
     end
@@ -345,7 +348,7 @@ describe RubyFit::MessageWriter do
     end
 
     it "returns the correct value for :record" do 
-      expect(described_class.definition_message_size(:record)).to eq(6 + 5*3)
+      expect(described_class.definition_message_size(:record)).to eq(6 + 8*3)
     end
 
     it "returns the correct value for :event" do 
@@ -371,7 +374,7 @@ describe RubyFit::MessageWriter do
     end
 
     it "returns the correct value for :record" do 
-      expect(described_class.data_message_size(:record)).to eq(19)
+      expect(described_class.data_message_size(:record)).to eq(23)
     end
 
     it "returns the correct value for :event" do 

--- a/spec/rubyfit/parser_spec.rb
+++ b/spec/rubyfit/parser_spec.rb
@@ -2,54 +2,6 @@ require 'spec_helper'
 require 'date'
 
 describe RubyFit::FitParser do
-  class TestCallbacks
-    attr_reader :file_id, :lap, :records, :events
-
-    def initialize
-      @file_id = nil
-      @lap = nil
-      @records = []
-      @events = []
-    end
-
-    def print_msg(msg)
-    end
-
-    def print_error_msg(msg)
-    end
-
-    def on_file_id(msg)
-      @file_id = msg
-    end
-
-    def on_activity(msg)
-    end
-
-    def on_lap(msg)
-      @lap = msg
-    end
-
-    def on_session(msg)
-    end
-
-    def on_record(msg)
-      @records << msg
-    end
-
-    def on_event(msg)
-      @events << msg
-    end
-
-    def on_device_info(msg)
-    end
-
-    def on_user_profile(msg)
-    end
-
-    def on_weight_scale_info(msg)
-    end
-  end
-
   describe "#parse" do
     let(:start_time) { DateTime.new(2025, 1, 1, 12, 0, 0).to_time.to_i }
 

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -260,9 +260,9 @@ describe RubyFit::Writer do
       1, 4, 133, # position long
       5, 4, 134, # distance
       2, 2, 132, # altitude
-      3, 1, 2, # heart_rate (uint8)
-      4, 1, 2, # cadence (uint8)
-      7, 2, 132, # power (uint16)
+      3, 1, 2, # heart_rate
+      4, 1, 2, # cadence
+      7, 2, 132, # power
     ]
     expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
     
@@ -278,9 +278,9 @@ describe RubyFit::Writer do
         *position_bytes(data[:x]), # lng
         *distance_bytes(distance), # distance
         *altitude_bytes(data[:elevation]), # elevation
-        data[:heart_rate], # heart_rate (uint8)
-        data[:cadence], # cadence (uint8)
-        *num2bytes(data[:power], 2), # power (uint16, big endian)
+        data[:heart_rate],
+        data[:cadence],
+        *num2bytes(data[:power], 2),
       ]
 
       expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -127,7 +127,7 @@ describe RubyFit::Writer do
       0, 0, 0, 0, # Serial number
       *timestamp_bytes(start_time), # Time created
       0, 1, # Manufacturer (garmin)
-      *num2bytes(RubyFit::Writer::PRODUCT_ID, 2), # Product
+      *num2bytes(RubyFit::Writer::GARMIN_CONNECT_PRODUCT_ID, 2), # Product
       6, # Type (course file)
     ]
     expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
@@ -253,13 +253,16 @@ describe RubyFit::Writer do
       0, # Padding
       1, # Big endian
       0, 20, # Global message number
-      5, # Field count
+      8, # Field count (updated from 5 to 8)
       # Fields are 3 bytes each - field ID, size in bytes, type ID
       253, 4, 134, # timestamp
       0, 4, 133, # position lat
       1, 4, 133, # position long
       5, 4, 134, # distance
       2, 2, 132, # altitude
+      3, 1, 2, # heart_rate
+      4, 1, 2, # cadence
+      7, 2, 132, # power
     ]
     expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
     
@@ -275,8 +278,11 @@ describe RubyFit::Writer do
         *position_bytes(data[:x]), # lng
         *distance_bytes(distance), # distance
         *altitude_bytes(data[:elevation]), # elevation
+        255, # heart_rate, default value when not provided
+        255, # cadence, default value when not provided
+        255, 255, # power (uint16) default value when not provided
       ]
-      
+
       expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
     end
     

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -359,7 +359,9 @@ describe RubyFit::Writer do
       total_calories: 500,
       avg_heart_rate: 145,
       avg_cadence: 86,
-      max_speed: 8000
+      max_speed: 8000,
+      manufacturer: 999,
+      product: 123
     }
 
     writer.write_activity(stream, opts) do
@@ -391,6 +393,9 @@ describe RubyFit::Writer do
     records = callbacks.records
     session = callbacks.session
 
+    expect(callbacks.file_id["manufacturer"]).to eq(999)
+    expect(callbacks.file_id["product"]).to eq(123)
+
     # Verify we got all the records
     expect(records.size).to eq(track_points.size)
 
@@ -409,5 +414,46 @@ describe RubyFit::Writer do
     expect(session["max_speed"]).to eq(8.0) # Speed is converted to m/s
     expect(session["sport"]).to eq(2)
     expect(session["sub_sport"]).to eq(0)
+  end
+
+  it "raises an error when providing manufacturer but no product" do
+    writer = described_class.new
+    stream = StringIO.new
+    start_time = DateTime.new(2018, 1, 1, 12, 0, 0).to_time.to_i
+
+    opts = {
+      time_created: start_time,
+      start_time: start_time,
+      duration: 3600,
+      start_x: track_points.first[:x],
+      start_y: track_points.first[:y],
+      end_x: track_points.last[:x],
+      end_y: track_points.last[:y],
+      total_distance: total_distance,
+      track_point_count: track_points.size,
+      manufacturer: 999
+    }
+
+    expect { writer.write_activity(stream, opts) }.to raise_error(ArgumentError)
+  end
+  it "raises an error when providing product but no manufacturer" do
+    writer = described_class.new
+    stream = StringIO.new
+    start_time = DateTime.new(2018, 1, 1, 12, 0, 0).to_time.to_i
+
+    opts = {
+      time_created: start_time,
+      start_time: start_time,
+      duration: 3600,
+      start_x: track_points.first[:x],
+      start_y: track_points.first[:y],
+      end_x: track_points.last[:x],
+      end_y: track_points.last[:y],
+      total_distance: total_distance,
+      track_point_count: track_points.size,
+      product: 123
+    }
+
+    expect { writer.write_activity(stream, opts) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rubyfit/writer_spec.rb
+++ b/spec/rubyfit/writer_spec.rb
@@ -7,11 +7,11 @@ describe RubyFit::Writer do
 
   let(:track_points) {
     [
-      {x: -122.64424, y: 45.5279, distance: 0, elevation: 100.0},
-      {x: -122.64355, y: 45.5279, distance: 53.81, elevation: 110.1},
-      {x: -122.64343, y: 45.52791, distance: 63.234, elevation: 120.2},
-      {x: -122.64342, y: 45.52858, distance: 137.822, elevation: 109.3},
-      {x: -122.64251, y: 45.52858, distance: 208.788, elevation: 122.4}
+      {x: -122.64424, y: 45.5279, distance: 0, elevation: 100.0, heart_rate: 140, cadence: 85, power: 220},
+      {x: -122.64355, y: 45.5279, distance: 53.81, elevation: 110.1, heart_rate: 145, cadence: 88, power: 235},
+      {x: -122.64343, y: 45.52791, distance: 63.234, elevation: 120.2, heart_rate: 150, cadence: 90, power: 245},
+      {x: -122.64342, y: 45.52858, distance: 137.822, elevation: 109.3, heart_rate: 148, cadence: 87, power: 230},
+      {x: -122.64251, y: 45.52858, distance: 208.788, elevation: 122.4, heart_rate: 142, cadence: 84, power: 225}
     ]
   }
 
@@ -260,9 +260,9 @@ describe RubyFit::Writer do
       1, 4, 133, # position long
       5, 4, 134, # distance
       2, 2, 132, # altitude
-      3, 1, 2, # heart_rate
-      4, 1, 2, # cadence
-      7, 2, 132, # power
+      3, 1, 2, # heart_rate (uint8)
+      4, 1, 2, # cadence (uint8)
+      7, 2, 132, # power (uint16)
     ]
     expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
     
@@ -278,9 +278,9 @@ describe RubyFit::Writer do
         *position_bytes(data[:x]), # lng
         *distance_bytes(distance), # distance
         *altitude_bytes(data[:elevation]), # elevation
-        255, # heart_rate, default value when not provided
-        255, # cadence, default value when not provided
-        255, 255, # power (uint16) default value when not provided
+        data[:heart_rate], # heart_rate (uint8)
+        data[:cadence], # cadence (uint8)
+        *num2bytes(data[:power], 2), # power (uint16, big endian)
       ]
 
       expect(bytes.shift(expected_bytes.size)).to eq(expected_bytes)
@@ -336,5 +336,78 @@ describe RubyFit::Writer do
     end
 
     stream.close
+  end
+
+  it "writes a valid activity FIT file" do
+    writer = described_class.new
+    stream = StringIO.new
+    start_time = DateTime.new(2018, 1, 1, 12, 0, 0).to_time.to_i
+    duration = 3600
+
+    opts = {
+      time_created: start_time,
+      start_time: start_time,
+      duration: duration,
+      start_x: track_points.first[:x],
+      start_y: track_points.first[:y],
+      end_x: track_points.last[:x],
+      end_y: track_points.last[:y],
+      total_distance: total_distance,
+      track_point_count: track_points.size,
+      sport: :cycling,
+      sub_sport: :generic,
+      total_calories: 500,
+      avg_heart_rate: 145,
+      avg_cadence: 86,
+      max_speed: 8000
+    }
+
+    writer.write_activity(stream, opts) do
+      writer.track_points do
+        timestamp = start_time
+        track_points.each do |data|
+          values = {
+            timestamp: timestamp,
+            x: data[:x],
+            y: data[:y],
+            distance: data[:distance],
+            elevation: data[:elevation],
+            heart_rate: data[:heart_rate],
+            cadence: data[:cadence],
+            power: data[:power]
+          }
+          writer.track_point(values)
+          timestamp += 60 # Increment by 60 seconds for each point
+        end
+      end
+    end
+
+    stream.rewind
+
+    callbacks = TestCallbacks.new
+    parser = RubyFit::FitParser.new(callbacks)
+    parser.parse(stream.read)
+
+    records = callbacks.records
+    session = callbacks.session
+
+    # Verify we got all the records
+    expect(records.size).to eq(track_points.size)
+
+    # Verify the first record has the expected data
+    first_record = records.first
+    expect(first_record["heart_rate"]).to eq(140)
+    expect(first_record["cadence"]).to eq(85)
+    expect(first_record["power"]).to eq(220)
+    expect(first_record["position_lat"]).to be_within(0.001).of(45.5279)
+    expect(first_record["position_long"]).to be_within(0.001).of(-122.64424)
+
+    # Verify session has the aggregated stats
+    expect(session["avg_heart_rate"]).to eq(145)
+    expect(session["avg_cadence"]).to eq(86)
+    expect(session["total_calories"]).to eq(500)
+    expect(session["max_speed"]).to eq(8.0) # Speed is converted to m/s
+    expect(session["sport"]).to eq(2)
+    expect(session["sub_sport"]).to eq(0)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,53 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 end
+
+class TestCallbacks
+  attr_reader :file_id, :lap, :records, :events, :session
+
+  def initialize
+    @file_id = nil
+    @lap = nil
+    @records = []
+    @events = []
+    @session = nil
+  end
+
+  def print_msg(msg)
+  end
+
+  def print_error_msg(msg)
+  end
+
+  def on_file_id(msg)
+    @file_id = msg
+  end
+
+  def on_activity(msg)
+  end
+
+  def on_lap(msg)
+    @lap = msg
+  end
+
+  def on_session(msg)
+    @session = msg
+  end
+
+  def on_record(msg)
+    @records << msg
+  end
+
+  def on_event(msg)
+    @events << msg
+  end
+
+  def on_device_info(msg)
+  end
+
+  def on_user_profile(msg)
+  end
+
+  def on_weight_scale_info(msg)
+  end
+end


### PR DESCRIPTION
This adds support for additional optional fields when using the writer, passed in via the `opts` hash.

`avg_heart_rate` and `avg_cadence` are now supported in the `write_activity` method and included in the session message.

`manufacturer` and `product` are now supported in both the `write_activity` and `write` methods. When provided, they will get written in the file_id message, otherwise the existing defaults will continue to be used.

This also fixes tests that were failing after previous addition of `heart_rate` `cadence` and `power` support.
